### PR TITLE
[Feature] #77, #78, #79 : Filtering category with selectable list cells

### DIFF
--- a/DaeguGoodPriceShop/DaeguGoodPriceShop.xcodeproj/project.pbxproj
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		DA34E7092873D9DD0038EDE4 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA34E7082873D9DD0038EDE4 /* LocationManager.swift */; };
 		DA34E70B2873DBDC0038EDE4 /* ShopAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA34E70A2873DBDC0038EDE4 /* ShopAnnotation.swift */; };
 		DA4A1986287A9583004E019F /* ModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4A1985287A9583004E019F /* ModalViewController.swift */; };
-		DA4A1988287A9596004E019F /* DefaultModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4A1987287A9596004E019F /* DefaultModalViewController.swift */; };
+		DA4A1988287A9596004E019F /* StoreListModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4A1987287A9596004E019F /* StoreListModalViewController.swift */; };
 		DA4A198A287A95B0004E019F /* DetailModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4A1989287A95B0004E019F /* DetailModalViewController.swift */; };
 		DA4A198C287A95C4004E019F /* CategoryModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4A198B287A95C4004E019F /* CategoryModalViewController.swift */; };
 		DA4A198E287A95D9004E019F /* ModalHeight.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4A198D287A95D9004E019F /* ModalHeight.swift */; };
@@ -73,7 +73,7 @@
 		DA34E7082873D9DD0038EDE4 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		DA34E70A2873DBDC0038EDE4 /* ShopAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopAnnotation.swift; sourceTree = "<group>"; };
 		DA4A1985287A9583004E019F /* ModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalViewController.swift; sourceTree = "<group>"; };
-		DA4A1987287A9596004E019F /* DefaultModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultModalViewController.swift; sourceTree = "<group>"; };
+		DA4A1987287A9596004E019F /* StoreListModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreListModalViewController.swift; sourceTree = "<group>"; };
 		DA4A1989287A95B0004E019F /* DetailModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailModalViewController.swift; sourceTree = "<group>"; };
 		DA4A198B287A95C4004E019F /* CategoryModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModalViewController.swift; sourceTree = "<group>"; };
 		DA4A198D287A95D9004E019F /* ModalHeight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalHeight.swift; sourceTree = "<group>"; };
@@ -209,7 +209,7 @@
 			isa = PBXGroup;
 			children = (
 				DA4A1985287A9583004E019F /* ModalViewController.swift */,
-				DA4A1987287A9596004E019F /* DefaultModalViewController.swift */,
+				DA4A1987287A9596004E019F /* StoreListModalViewController.swift */,
 				F240E3F9287C54A00033A8FA /* ModalCollectionViewCell */,
 				DA4A1989287A95B0004E019F /* DetailModalViewController.swift */,
 				DA4A198B287A95C4004E019F /* CategoryModalViewController.swift */,
@@ -329,7 +329,7 @@
 				A8CBA577287BAF3800BC2DC1 /* ChineseFoodAnnotationView.swift in Sources */,
 				A80AAF972876508400795C87 /* ShopAnnotationView.swift in Sources */,
 				A8E74E8A286BFBB5000DB2B8 /* Shop.swift in Sources */,
-				DA4A1988287A9596004E019F /* DefaultModalViewController.swift in Sources */,
+				DA4A1988287A9596004E019F /* StoreListModalViewController.swift in Sources */,
 				F240E3FD287C55850033A8FA /* DetailCategoryViewCell.swift in Sources */,
 				A8CBA582287BAF3800BC2DC1 /* HairCutAnnotationView.swift in Sources */,
 				A8CBA57E287BAF3800BC2DC1 /* KoreanFoodAnnotationView.swift in Sources */,

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/Entity/ModalHeight.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/Entity/ModalHeight.swift
@@ -26,7 +26,7 @@ enum ModalHeight{
             case .maximum:
                 return UIScreen.main.bounds.height - 70
             case .category:
-                return UIScreen.main.bounds.height / 2
+                return UIScreen.main.bounds.height / 2 - 30
             }
         }
     }

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/Model/DataItem.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/Model/DataItem.swift
@@ -7,29 +7,41 @@
 
 import UIKit
 
-
 class DataItem: Hashable {
-    let categoryName: String?
-    let categoryColor: UIColor?
-    
+    let shopSubCategory: ShopSubCategory?
+    var categoryColor: UIColor? {
+        switch self.shopSubCategory {
+        case .koreanFood, .chineseFood, .westernFood, .japaneseFood, .flourBasedFood, .bakery, .cafe:
+            return UIColor(named: "CateringStore")
+        case .hairCut:
+            return UIColor(named: "HairCut")
+        case .cleaning:
+            return UIColor(named: "LaundryShop")
+        case .skinCare, .bath:
+            return UIColor(named: "ServiceShop")
+        case .none:
+            return .black
+        }
+    }
     let storeName: String?
     let storeAddress: String?
     let storeCallNumber: String?
+    let storeSerialNumber: Int?
     
-    init(categoryName: String?, categoryColor: UIColor?, storeName: String?, storeAddress: String?, storeCallNumber: String?) {
-        self.categoryName = categoryName
-        self.categoryColor = categoryColor
+    init(shopSubCategory: ShopSubCategory?, storeName: String?, storeAddress: String?, storeCallNumber: String?, storeSerialNumber: Int?) {
+        self.shopSubCategory = shopSubCategory
         self.storeName = storeName
         self.storeAddress = storeAddress
         self.storeCallNumber = storeCallNumber
+        self.storeSerialNumber = storeSerialNumber
     }
     
-    convenience init(categoryName: String, categoryColor: UIColor?) {
-        self.init(categoryName: categoryName, categoryColor: categoryColor, storeName: nil, storeAddress: nil, storeCallNumber: nil)
+    convenience init(shopSubCategory: ShopSubCategory?) {
+        self.init(shopSubCategory: shopSubCategory, storeName: nil, storeAddress: nil, storeCallNumber: nil, storeSerialNumber: nil)
     }
     
-    convenience init(storeName: String?, storeAddress: String?, storeCallNumber: String?) {
-        self.init(categoryName: nil, categoryColor: nil, storeName: storeName, storeAddress: storeAddress, storeCallNumber: storeCallNumber)
+    convenience init(storeName: String?, storeAddress: String?, storeCallNumber: String?, storeSerialNumber: Int?) {
+        self.init(shopSubCategory: nil, storeName: storeName, storeAddress: storeAddress, storeCallNumber: storeCallNumber, storeSerialNumber: storeSerialNumber)
     }
     
     func hash(into hasher: inout Hasher) {
@@ -44,28 +56,8 @@ class DataItem: Hashable {
 }
 
 extension DataItem {
-    static let categories: [DataItem] = [
-        DataItem(categoryName: "한식", categoryColor: UIColor.black),
-        DataItem(categoryName: "분식", categoryColor: UIColor.black),
-        DataItem(categoryName: "중식", categoryColor: UIColor.black),
-        DataItem(categoryName: "양식", categoryColor: UIColor.black),
-        DataItem(categoryName: "일식", categoryColor: UIColor.black),
-    ]
-    
     static let favourites: [DataItem] = [
-        DataItem(storeName: "착한가격식당11", storeAddress: "포항시 어디구 여기동 저기로 1", storeCallNumber: "07011111111"),
-        DataItem(storeName: "착한가격식당12", storeAddress: "포항시 어디구 여기동 저기로 2", storeCallNumber: "07022222222")
-    ]
-    
-    static let normals: [DataItem] = [
-        DataItem(storeName:  "착한가격식당1", storeAddress: "포항시 어디구 여기동 저기로 1", storeCallNumber: "07011111111"),
-        DataItem(storeName: "착한가격식당2", storeAddress: "포항시 어디구 여기동 저기로 2", storeCallNumber: "07022222222"),
-        DataItem(storeName: "착한가격식당3", storeAddress: "포항시 어디구 여기동 저기로 3", storeCallNumber: "07033333333"),
-        DataItem(storeName: "착한가격식당4", storeAddress: "포항시 어디구 여기동 저기로 4", storeCallNumber: "07044444444"),
-        DataItem(storeName: "착한가격식당5", storeAddress: "포항시 어디구 여기동 저기로 5", storeCallNumber: "07055555555"),
-        DataItem(storeName: "착한가격식당7", storeAddress: "포항시 어디구 여기동 저기로 3", storeCallNumber: "07033333333"),
-        DataItem(storeName: "착한가격식당8", storeAddress: "포항시 어디구 여기동 저기로 4", storeCallNumber: "07044444444"),
-        DataItem(storeName: "착한가격식당9", storeAddress: "포항시 어디구 여기동 저기로 5", storeCallNumber: "07055555555"),
-        DataItem(storeName: "착한가격식당10", storeAddress: "포항시 어디구 여기동 저기로 6", storeCallNumber: "07066666666")
+        DataItem(storeName: "착한가격식당11", storeAddress: "포항시 어디구 여기동 저기로 1", storeCallNumber: "07011111111", storeSerialNumber: 1),
+        DataItem(storeName: "착한가격식당12", storeAddress: "포항시 어디구 여기동 저기로 2", storeCallNumber: "07022222222", storeSerialNumber: 1)
     ]
 }

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/CategoryModalViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/CategoryModalViewController.swift
@@ -26,6 +26,13 @@ class CategoryModalViewController: ModalViewController {
         return label
     }()
     
+    lazy var innerScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.isScrollEnabled = false
+        return scrollView
+    }()
+    
     lazy var cateringStoreButtonView: UIStackView = {
         let imageView = UIImageView()
         let label = UILabel()
@@ -140,9 +147,11 @@ class CategoryModalViewController: ModalViewController {
     
     override func setupView() {
         super.setupView()
-        view.addSubview(dismissButton)
-        view.addSubview(textLabel)
-        view.addSubview(totalStackView)
+        view.addSubview(innerScrollView)
+        innerScrollView.addSubview(dismissButton)
+        innerScrollView.addSubview(textLabel)
+        innerScrollView.addSubview(totalStackView)
+        
         
         cateringStoreButtonView.layer.cornerRadius = 5
         hairdressingShop.layer.cornerRadius = 5
@@ -150,23 +159,30 @@ class CategoryModalViewController: ModalViewController {
         serviceShop.layer.cornerRadius = 5
         
         NSLayoutConstraint.activate([
-            textLabel.leftAnchor.constraint(equalTo: self.view.leftAnchor, constant: 30),
-            textLabel.topAnchor.constraint(equalTo: self.view.topAnchor, constant: 30)
+            innerScrollView.leftAnchor.constraint(equalTo: view.leftAnchor),
+            innerScrollView.topAnchor.constraint(equalTo: view.topAnchor),
+            innerScrollView.rightAnchor.constraint(equalTo: view.rightAnchor),
+            innerScrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
         
         NSLayoutConstraint.activate([
-            totalStackView.leftAnchor.constraint(equalTo: self.view.leftAnchor, constant: 30),
+            textLabel.leftAnchor.constraint(equalTo: innerScrollView.leftAnchor, constant: 30),
+            textLabel.topAnchor.constraint(equalTo: innerScrollView.topAnchor, constant: 30)
+        ])
+        
+        NSLayoutConstraint.activate([
+            totalStackView.leftAnchor.constraint(equalTo: innerScrollView.leftAnchor, constant: 30),
             totalStackView.topAnchor.constraint(equalTo: self.textLabel.bottomAnchor, constant: 30),
-            totalStackView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -50),
-            totalStackView.rightAnchor.constraint(equalTo: self.view.rightAnchor, constant: -30)
+            totalStackView.bottomAnchor.constraint(equalTo: innerScrollView.bottomAnchor, constant: -50),
+            totalStackView.rightAnchor.constraint(equalTo: innerScrollView.rightAnchor, constant: -30)
         ])
             
             
         NSLayoutConstraint.activate([
-            dismissButton.widthAnchor.constraint(equalToConstant: 30),
-            dismissButton.heightAnchor.constraint(equalToConstant: 30),
-            dismissButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 10),
-            dismissButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10),
+            dismissButton.widthAnchor.constraint(equalToConstant: 50),
+            dismissButton.heightAnchor.constraint(equalToConstant: 50),
+            dismissButton.topAnchor.constraint(equalTo: innerScrollView.topAnchor, constant: 10),
+            dismissButton.trailingAnchor.constraint(equalTo: innerScrollView.trailingAnchor, constant: -10),
         ])
     }
     

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/DetailModalViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/DetailModalViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class DetailModalViewController: ModalViewController {
-    lazy var defaultViewController = parent?.children.first(where: { $0 is DefaultModalViewController }) as! DefaultModalViewController
+    lazy var defaultViewController = parent?.children.first(where: { $0 is StoreListModalViewController }) as! StoreListModalViewController
     lazy var mapViewModel = (parent as? MapViewController)?.mapViewModel
     private var selectedShop: Shop? {
         didSet {

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/ModalCollectionViewCell/DetailCategoryViewCell.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/ModalCollectionViewCell/DetailCategoryViewCell.swift
@@ -18,6 +18,7 @@ class DetailCategoryViewCell: UICollectionViewCell {
         button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 18)
         button.titleLabel?.textColor = .white
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.isUserInteractionEnabled = false
         
         return button
     }()
@@ -26,15 +27,13 @@ class DetailCategoryViewCell: UICollectionViewCell {
         configureView()
         
         categoryItemButton.backgroundColor = item.categoryColor ?? .black
-        categoryItemButton.setTitle(item.categoryName ?? "", for: .normal)
+        categoryItemButton.setTitle(item.shopSubCategory?.rawValue ?? "", for: .normal)
     }
 }
 
 extension DetailCategoryViewCell {
     private func configureView() {
-        [
-            categoryItemButton
-        ].forEach { addSubview($0) }
+        addSubview(categoryItemButton)
         
         NSLayoutConstraint.activate([
             categoryItemButton.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 0),


### PR DESCRIPTION
# Issue Number
🔒 Close #77
🔒 Close #78
🔒 Close #79 

## New features

- 선택한 카테고리에 맞게 서브카테고리가 나타남
- 선택한 카테고리에 맞게 가게가 리스트 형태로 나타남
- 가게를 선택하면 해당 가게로 지도를 이동

## Review points

- 카테고리에서 chips가 선택이 안되는 버그가 있습니다.
    - chips가 재사용되면서 선택이 안되는 문제가 있는 것 같습니다.
- 업소 리스트에서 업소를 선택하면 zoom 됩니다. 이 때 ModalView의 .category size를 UIScreen.main.height/2 - 30으로 하였습니다. 이유는 줌되었을 때 Annotation이 보이게 하기 위함.
- categoryModalView가 깨져서 ScrollView를 넣었는데, 그래도 깨집니다.
    -  StackView의 size가 내부의 크기에 의해 결정되기 때문에 발생하는 문제인데, 고민이 필요합니다.

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
