### PR TITLE
[Bug] #101 : Fix  func_resizedImage

### DIFF
--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/AnnotationView/ShopAnnotationView.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/AnnotationView/ShopAnnotationView.swift
@@ -29,13 +29,14 @@ class ShopAnnotationView: MKAnnotationView {
     }
     
     func resizedImage(image: UIImage?, width: CGFloat, height: CGFloat) -> UIImage? {
-        guard let image = image else { return nil }
-        UIGraphicsBeginImageContext(CGSize(width: width, height: height))
-        image.draw(in: CGRect(x: 0, y: 0, width: width, height: height))
-        let newImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return newImage
-    }
+         guard let image = image else { return nil }
+         let newSize = CGSize(width: width, height: height)
+         UIGraphicsBeginImageContextWithOptions(newSize, false, UIScreen.main.scale)
+         image.draw(in: CGRect(x: 0, y: 0, width: width, height: height))
+         let newImage = UIGraphicsGetImageFromCurrentImageContext()
+         UIGraphicsEndImageContext()
+         return newImage
+     }
     
     func selected() {
         self.centerOffset = CGPoint(x: 0, y: -24.96)


### PR DESCRIPTION
# Issue Number
🔒 Close #101

## New features

- write here
func resizedImage 구문 내 UIGraphicsBeginImageContextWithOptions 추가

- screenshot(optional)
Before Bug Fix
<img width="279" alt="스크린샷 2022-07-15 오전 1 36 06" src="https://user-images.githubusercontent.com/40324511/179032879-de8e5bd9-9b89-4345-9efc-99092cb7b427.png">

After Bug Fix
<img width="319" alt="스크린샷 2022-07-15 오전 1 34 39" src="https://user-images.githubusercontent.com/40324511/179032832-c7bff7b0-0a4f-492a-83cd-0ae00393435b.png">


## Review points

- write here
ShopAnnotationView.swift 내의 func resizedImage 코드
