### PR TITLE
[Bug] #124 : Unfiltering

### DIFF
--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
@@ -271,9 +271,7 @@ extension MapViewController: MKMapViewDelegate {
         
         detailModalVC.setData(shopId: selectedShopData.serialNumber)
         detailModalVC.initModal()
-        categoryModalVC.changeModalHeight(.zero)
-        storeListModalVC.changeModalHeight(.zero)
-//        zoomTo(shop: mapViewModel.findShop(shopId: selectedShopData.serialNumber)!)
+        zoomTo(shop: mapViewModel.findShop(shopId: selectedShopData.serialNumber)!)
     }
     
     //    func mapView(_ mapView: MKMapView, annotationView view: MKAnnotationView, calloutAccessoryControlTapped control: UIControl) {


### PR DESCRIPTION
# Issue Number
🔒 Close #124

## New features

```swift
categoryModalVC.changeModalHeight(.zero)
storeListModalVC.changeModalHeight(.zero)
```
- 위 구문을 제거하여 필터링된 경우에 해당 modal이 내려가지 않도록 하였습니다. 

## Questions

- zoomTo(shop: ) 함수를 주석처리했던 이유가 있을까요?
- 해당 함수는 annotationView가 touch되었을 때에 화면의 정 중앙에 놓이게 하는 함수입니다.
- 해당 함수가 없으면 annotationView가 touch되었을 때 detail Modal에 의해 가릴 수 있습니다.

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
