### PR TITLE
[Bug] #129 : Fix annotation filtering flashing

### DIFF
--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/Entity/ShopCategory.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/Entity/ShopCategory.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-enum ShopSubCategory: String {
+enum ShopSubCategory: String, CaseIterable {
     case koreanFood = "한식"
     case chineseFood = "중식"
     case westernFood = "양식"
@@ -47,7 +47,7 @@ enum ShopSubCategory: String {
     }
 }
 
-enum ShopCategory {
+enum ShopCategory: CaseIterable {
     case cateringStore
     case hairdressingShop
     case laundryShop

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/ViewModel/MapViewModel.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/ViewModel/MapViewModel.swift
@@ -83,6 +83,26 @@ final class MapViewModel {
         return model.filteredShops(shopCategory: shopCategory, shopSubCategory: shopSubCategory, favorite: favorite)
     }
     
+    func getShopsWithout(shopCategory: ShopCategory) -> [Shop] {
+        return ShopCategory.allCases.reduce([]) {
+            if $1 == shopCategory {
+                return $0
+            } else {
+                return $0 + model.filteredShops(shopCategory: $1)
+            }
+        }
+    }
+    
+    func getShopsWithout(shopSubCategory: ShopSubCategory) -> [Shop] {
+        return ShopSubCategory.allCases.reduce([]) {
+            if $1 == shopSubCategory {
+                return $0
+            } else {
+                return $0 + model.filteredShops(shopSubCategory: $1)
+            }
+        }
+    }
+    
     func findShop(shopId id: Int) -> Shop? {
         return model.findById(shopId: id)
     }


### PR DESCRIPTION
# Issue Number
🔒 Close #129 

## New features

- 선택한 카테고리에 해당하는 annotationView는 깜빡이지 않습니다.
- <img src="https://user-images.githubusercontent.com/81242125/179358083-9b6bb1c5-803b-43dc-a92a-4fe996ccadc0.gif">

## Review points

- ViewModel에 고차함수와 함수형 프로그래밍을 적극 활용하여 해당 기능을 구현했습니다.
- 하지만, shopSubCategory에서는 깜빡이게 되는데, 이는 수정하기 곤란합니다.
    - 이유는 ShopCategory가 filtering 된 상태에서와 다른 ShopSubCategory가 filtering된 상태를 분기해야 하기 때문입니다.

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
