### PR TITLE
[Bug] #131 : Fix category modal view pan gesture view height

### DIFF
--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/CategoryModalViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/CategoryModalViewController.swift
@@ -164,14 +164,14 @@ class CategoryModalViewController: ModalViewController {
         
         NSLayoutConstraint.activate([
             innerScrollView.leftAnchor.constraint(equalTo: view.leftAnchor),
-            innerScrollView.topAnchor.constraint(equalTo: gestureBarView.bottomAnchor),
+            innerScrollView.topAnchor.constraint(equalTo: gestureView.bottomAnchor, constant: -30),
             innerScrollView.rightAnchor.constraint(equalTo: view.rightAnchor),
             innerScrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
         
         NSLayoutConstraint.activate([
             textLabel.leftAnchor.constraint(equalTo: innerScrollView.leftAnchor, constant: 30),
-            textLabel.topAnchor.constraint(equalTo: innerScrollView.topAnchor, constant: 30)
+            textLabel.topAnchor.constraint(equalTo: innerScrollView.topAnchor)
         ])
         
         NSLayoutConstraint.activate([


### PR DESCRIPTION
# Issue Number
🔒 Close #131

## New features

- Category Modal View의 Pan gesture view의 높이가 다른 Modal View와 동일합니다.
- <img height=600 src="https://user-images.githubusercontent.com/81242125/179359800-9f9c328b-9eed-465d-a536-b28762568a3d.jpg">

## Questions

- 모든 ModalView의 Superclass인 ModalViewController에서 PanGestureView의 height가 70으로 설정되어 있습니다.
- 그러나 StoreListModalView와 DetailModalView에서 실질적인 PanGestureView의 height가 40입니다.
- 이렇게 설계된 이유가 있을까요?

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
