### PR TITLE
[Feature] #173 : Zoom to Cluster

### DIFF
--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/Model/MapModel.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/Model/MapModel.swift
@@ -85,4 +85,3 @@ final class MapModel {
         return totalShops.first(where: {$0.serialNumber == id })
     }
 }
-

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/AnnotationView/ClusteringAnnotationView.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/AnnotationView/ClusteringAnnotationView.swift
@@ -9,7 +9,6 @@ import MapKit
 
 final class ClusteringAnnotationView: MKAnnotationView {
     static let identifier = "ClusteringAnnotationView"
-    
     override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
         super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
         collisionMode = .circle

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/AnnotationView/ClusteringAnnotationView.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/AnnotationView/ClusteringAnnotationView.swift
@@ -9,10 +9,19 @@ import MapKit
 
 final class ClusteringAnnotationView: MKAnnotationView {
     static let identifier = "ClusteringAnnotationView"
+    override var rightCalloutAccessoryView: UIView? {
+        get {
+            let clusterAnnotationZoomButton = UIButton(frame: CGRect(x: 0, y: 0, width: 30, height: 30))
+            clusterAnnotationZoomButton.setImage(UIImage(systemName: "plus.magnifyingglass"), for: .normal)
+            return  clusterAnnotationZoomButton
+        }
+        set {}
+    }
     override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
         super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
         collisionMode = .circle
         centerOffset = CGPoint(x: 0, y: -10)
+        //var rightCalloutAccessoryView = UIButton(frame: CGRect(x: 0, y: 0, width: 30, height: 30))
     }
     
     required init?(coder aDecoder: NSCoder) {

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/AnnotationView/ClusteringAnnotationView.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/AnnotationView/ClusteringAnnotationView.swift
@@ -19,7 +19,6 @@ final class ClusteringAnnotationView: MKAnnotationView {
     required init?(coder aDecoder: NSCoder) {
         fatalError("This method cannot be called.")
     }
-    
     override func prepareForDisplay() {
         super.prepareForDisplay()
         guard let cluster = annotation as? MKClusterAnnotation else { return }

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
@@ -345,7 +345,6 @@ extension MapViewController: MKMapViewDelegate {
             guard let selectedAnnotationData = clusteringAnnotationView.annotation as? MKClusterAnnotation else {
                 return
             }
-            print(selectedAnnotationData.coordinate)
             zoomToCluster(clusteringAnnotation: selectedAnnotationData)
         }
     }
@@ -410,13 +409,6 @@ extension MapViewController: SubCategoryFilterable {
     }
     
     func shopTouched(ofSerialNumber number: Int) {
-        guard let touchedShopIndex = shopViewModel.getShops().firstIndex(where: { $0.serialNumber == number }) else { return }
-        let touchedShop = shopViewModel.getShops()[touchedShopIndex]
-        zoomTo(shop: touchedShop)
-    }
-    
-    // ClusterTouch
-    func clusterTouched(ofSerialNumber number: Int) {
         guard let touchedShopIndex = shopViewModel.getShops().firstIndex(where: { $0.serialNumber == number }) else { return }
         let touchedShop = shopViewModel.getShops()[touchedShopIndex]
         zoomTo(shop: touchedShop)

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
@@ -26,7 +26,7 @@ class MapViewController: UIViewController {
         return button
     }()
     
-@IBOutlet weak var likeButton: UIButton!
+    @IBOutlet weak var likeButton: UIButton!
     @IBOutlet weak var categoryButton: UIButton!
     @IBOutlet weak var buttonsContainerView: UIView!
     
@@ -326,10 +326,6 @@ extension MapViewController: MKMapViewDelegate {
     
     func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
         selectedAnnotationView?.prepareForDisplay()
-        /*
-        guard let shopAnnotationView = view as? ShopAnnotationView else {
-            return
-        }*/
         if let shopAnnotationView = view as? ShopAnnotationView {
             shopAnnotationView.selected()
             selectedAnnotationView = view

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
@@ -342,9 +342,9 @@ extension MapViewController: MKMapViewDelegate {
             selectedAnnotationView = clusteringAnnotationView
             selectedAnnotation = selectedAnnotationView?.annotation
             
-            let leftIconView = UIButton(frame: CGRect(x: 0, y: 0, width: 30, height: 30))
-            leftIconView.setImage(UIImage(systemName: "plus.magnifyingglass"), for: .normal)
-            selectedAnnotationView?.rightCalloutAccessoryView = leftIconView
+            let clusterAnnotationZoomButton = UIButton(frame: CGRect(x: 0, y: 0, width: 30, height: 30))
+            clusterAnnotationZoomButton.setImage(UIImage(systemName: "plus.magnifyingglass"), for: .normal)
+            selectedAnnotationView?.rightCalloutAccessoryView = clusterAnnotationZoomButton
         }
     }
     

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
@@ -320,13 +320,11 @@ extension MapViewController: MKMapViewDelegate {
     }
     
     func mapView(_ mapView: MKMapView, didDeselect view: MKAnnotationView) {
-        print("1번 취소")
         selectedAnnotationView?.prepareForDisplay()
         detailModalVC.dismissModal()
     }
     
     func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
-        print("2번 일반")
         selectedAnnotationView?.prepareForDisplay()
         if let shopAnnotationView = view as? ShopAnnotationView {
             shopAnnotationView.selected()
@@ -351,7 +349,6 @@ extension MapViewController: MKMapViewDelegate {
     }
     
     func mapView(_ mapView: MKMapView, annotationView view: MKAnnotationView, calloutAccessoryControlTapped control: UIControl) {
-        print("3번 줌 투 클러스터")
         guard view is ClusteringAnnotationView else {
             return
         }
@@ -363,7 +360,6 @@ extension MapViewController: MKMapViewDelegate {
         }
         zoomToCluster(clusteringAnnotation: selectedAnnotation)
     }
-    
 }
 
 extension MapViewController: CategoryFilterable {
@@ -372,7 +368,6 @@ extension MapViewController: CategoryFilterable {
         updateAnnotation(category: category)
         storeListModalVC.initModal()
     }
-    
     
     func removeCategoryFiltering() {
         updateAnnotation(category: nil)

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
@@ -280,9 +280,9 @@ class MapViewController: UIViewController {
             let latitudeGap = Double(bigLatitude) - Double(smallLatitude)
             let longitudeGap = Double(bigLongitude) - Double(smallLongitude)
             if latitudeGap >= longitudeGap{
-                return latitudeGap + 0.0001
+                return latitudeGap + 0.001
             } else {
-                return longitudeGap + 0.0001
+                return longitudeGap + 0.001
             }
         } else {
             return 0.01

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
@@ -341,10 +341,6 @@ extension MapViewController: MKMapViewDelegate {
         } else if let clusteringAnnotationView = view as? ClusteringAnnotationView {
             selectedAnnotationView = clusteringAnnotationView
             selectedAnnotation = selectedAnnotationView?.annotation
-            
-            let clusterAnnotationZoomButton = UIButton(frame: CGRect(x: 0, y: 0, width: 30, height: 30))
-            clusterAnnotationZoomButton.setImage(UIImage(systemName: "plus.magnifyingglass"), for: .normal)
-            selectedAnnotationView?.rightCalloutAccessoryView = clusterAnnotationZoomButton
         }
     }
     

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/MapViewController.swift
@@ -319,34 +319,42 @@ extension MapViewController: MKMapViewDelegate {
         }
     }
     
+    func mapView(_ mapView: MKMapView, annotationView view: MKAnnotationView, calloutAccessoryControlTapped control: UIControl) {
+        print("1번")
+        selectedAnnotationView?.prepareForDisplay()
+        guard view is ClusteringAnnotationView else {
+            return
+        }
+        selectedAnnotationView = view
+        selectedAnnotation = selectedAnnotationView?.annotation
+        
+        guard let selectedAnnotation = view.annotation as? MKClusterAnnotation else {
+            return
+        }
+        zoomToCluster(clusteringAnnotation: selectedAnnotation)
+    }
+    
     func mapView(_ mapView: MKMapView, didDeselect view: MKAnnotationView) {
+        print("2번")
         selectedAnnotationView?.prepareForDisplay()
         detailModalVC.dismissModal()
     }
     
     func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
+        print("3번")
         selectedAnnotationView?.prepareForDisplay()
-        if let shopAnnotationView = view as? ShopAnnotationView {
-            shopAnnotationView.selected()
-            selectedAnnotationView = view
-            selectedAnnotation = selectedAnnotationView?.annotation
+        guard let shopAnnotationView = view as? ShopAnnotationView else { return }
+        shopAnnotationView.selected()
+        selectedAnnotationView = view
+        selectedAnnotation = selectedAnnotationView?.annotation
             
-            guard let selectedShopData = view.annotation as? ShopAnnotation else {
-                return
-            }
-            
-            detailModalVC.setData(shopId: selectedShopData.serialNumber)
-            detailModalVC.initModal()
-            zoomTo(shop: shopViewModel.findShop(shopId: selectedShopData.serialNumber)!)
-        } else if let clusteringAnnotationView = view as? ClusteringAnnotationView {
-            selectedAnnotationView = clusteringAnnotationView
-            selectedAnnotation = selectedAnnotationView?.annotation
-            
-            guard let selectedAnnotationData = clusteringAnnotationView.annotation as? MKClusterAnnotation else {
-                return
-            }
-            zoomToCluster(clusteringAnnotation: selectedAnnotationData)
+        guard let selectedShopData = view.annotation as? ShopAnnotation else {
+            return
         }
+            
+        detailModalVC.setData(shopId: selectedShopData.serialNumber)
+        detailModalVC.initModal()
+        zoomTo(shop: shopViewModel.findShop(shopId: selectedShopData.serialNumber)!)
     }
 }
 

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/ViewModel/MapShopViewModel.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/ViewModel/MapShopViewModel.swift
@@ -67,7 +67,7 @@ final class MapShopViewModel {
             return model.filteredShops(shopCategory: category, shopSubCategory: subcategory, isShowFavorite: favorite)
         }
     }
-    
+
     func findShop(shopId id: Int) -> Shop? {
         return model.findById(shopId: id)
     }

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/ViewModel/MapShopViewModel.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/ViewModel/MapShopViewModel.swift
@@ -67,7 +67,6 @@ final class MapShopViewModel {
             return model.filteredShops(shopCategory: category, shopSubCategory: subcategory, isShowFavorite: favorite)
         }
     }
-
     func findShop(shopId id: Int) -> Shop? {
         return model.findById(shopId: id)
     }


### PR DESCRIPTION
# Issue Number
🔒 Close #173

## New features

- Cluster를 터치했을 때, 나오는 Callout zoom Button을 클릭하면 지도가 그 부분으로 확대됩니다.
- 확대되는 곳의 중심은 Cluster member annotations의 좌표 평균값입니다.
- 얼마나 확대될지는 member annotation들이 한번에 다 담길수 있게 유동적으로 자동 조절됩니다.

![Simulator Screen Recording - iPhone SE (3rd generation) - 2022-07-30 at 23 00 42](https://user-images.githubusercontent.com/57012734/181917810-245295a6-68b1-416b-afa6-33939266d3b1.gif)

## Review points

- Member annotations에 Cluster annotation이 있으면 확대되어도 Member cluster annotation의 Clustering은 유지됩니다.
- 확대가 잘 되는지 확인해주세요.

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
