### PR TITLE
[Refactor] #181 : Change UI DetailView & StoreList CellView & CategoryView 

### DIFF
--- a/DaeguGoodPriceShop/DaeguGoodPriceShop.xcodeproj/project.pbxproj
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		A8E74E79286BFA8B000DB2B8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A8E74E77286BFA8B000DB2B8 /* LaunchScreen.storyboard */; };
 		A8E74E88286BFBA5000DB2B8 /* MapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E74E87286BFBA5000DB2B8 /* MapModel.swift */; };
 		A8E74E8A286BFBB5000DB2B8 /* Shop.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E74E89286BFBB5000DB2B8 /* Shop.swift */; };
+		AFA6561C289583E100B6E912 /* BasePaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA6561B289583E100B6E912 /* BasePaddingLabel.swift */; };
 		DA34E7062873C7640038EDE4 /* ShopCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA34E7052873C7630038EDE4 /* ShopCategory.swift */; };
 		DA34E7092873D9DD0038EDE4 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA34E7082873D9DD0038EDE4 /* LocationManager.swift */; };
 		DA34E70B2873DBDC0038EDE4 /* ShopAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA34E70A2873DBDC0038EDE4 /* ShopAnnotation.swift */; };
@@ -79,6 +80,7 @@
 		A8E74E7A286BFA8B000DB2B8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A8E74E87286BFBA5000DB2B8 /* MapModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapModel.swift; sourceTree = "<group>"; };
 		A8E74E89286BFBB5000DB2B8 /* Shop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shop.swift; sourceTree = "<group>"; };
+		AFA6561B289583E100B6E912 /* BasePaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePaddingLabel.swift; sourceTree = "<group>"; };
 		DA34E7052873C7630038EDE4 /* ShopCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopCategory.swift; sourceTree = "<group>"; };
 		DA34E7082873D9DD0038EDE4 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		DA34E70A2873DBDC0038EDE4 /* ShopAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopAnnotation.swift; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 				A8E74E87286BFBA5000DB2B8 /* MapModel.swift */,
 				DA34E70A2873DBDC0038EDE4 /* ShopAnnotation.swift */,
 				F2277F78287EA1EA00FAB0B0 /* StoreListItem.swift */,
+				AFA6561B289583E100B6E912 /* BasePaddingLabel.swift */,
 				DA34E7082873D9DD0038EDE4 /* LocationManager.swift */,
 			);
 			path = Model;
@@ -352,6 +355,7 @@
 				DA34E7092873D9DD0038EDE4 /* LocationManager.swift in Sources */,
 				A8CBA579287BAF3800BC2DC1 /* BathAnnotationView.swift in Sources */,
 				A8CBA57F287BAF3800BC2DC1 /* ClusteringAnnotationView.swift in Sources */,
+				AFA6561C289583E100B6E912 /* BasePaddingLabel.swift in Sources */,
 				DA4A198A287A95B0004E019F /* DetailModalViewController.swift in Sources */,
 				DA34E7062873C7640038EDE4 /* ShopCategory.swift in Sources */,
 				F2277F79287EA1EA00FAB0B0 /* StoreListItem.swift in Sources */,

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/Application/Assets.xcassets/SubColorRed.colorset/Contents.json
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/Application/Assets.xcassets/SubColorRed.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x3E",
-          "green" : "0x48",
-          "red" : "0xF0"
+          "blue" : "0x5C",
+          "green" : "0x5C",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/Model/BasePaddingLabel.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/Model/BasePaddingLabel.swift
@@ -1,0 +1,29 @@
+//
+//  BasePaddingLabel.swift
+//  DaeguGoodPriceShop
+//
+//  Created by Yosep on 2022/07/31.
+//
+
+import UIKit
+
+class BasePaddingLabel: UILabel {
+    private var padding = UIEdgeInsets(top: 16.0, left: 16.0, bottom: 16.0, right: 16.0)
+
+    convenience init(padding: UIEdgeInsets) {
+        self.init()
+        self.padding = padding
+    }
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: padding))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        var contentSize = super.intrinsicContentSize
+        contentSize.height += padding.top + padding.bottom
+        contentSize.width += padding.left + padding.right
+
+        return contentSize
+    }
+}

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/CategoryModalViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/CategoryModalViewController.swift
@@ -37,7 +37,7 @@ class CategoryModalViewController: ModalViewController {
     
     lazy var cateringStoreButtonView: UIStackView = {
         let imageView = UIImageView()
-        let label = UILabel()
+        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0))
         let stackView = UIStackView(arrangedSubviews: [imageView, label])
         stackView.axis = .vertical
         stackView.distribution = .fill
@@ -59,7 +59,7 @@ class CategoryModalViewController: ModalViewController {
     
     lazy var hairdressingShop: UIStackView = {
         let imageView = UIImageView()
-        let label = UILabel()
+        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0))
         let stackView = UIStackView(arrangedSubviews: [imageView, label])
         stackView.axis = .vertical
         stackView.distribution = .fill
@@ -81,7 +81,7 @@ class CategoryModalViewController: ModalViewController {
     
     lazy var laundryShop: UIStackView = {
         let imageView = UIImageView()
-        let label = UILabel()
+        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0))
         let stackView = UIStackView(arrangedSubviews: [imageView, label])
         stackView.axis = .vertical
         stackView.distribution = .fill
@@ -103,7 +103,7 @@ class CategoryModalViewController: ModalViewController {
     
     lazy var serviceShop: UIStackView = {
         let imageView = UIImageView()
-        let label = UILabel()
+        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0))
         let stackView = UIStackView(arrangedSubviews: [imageView, label])
         stackView.axis = .vertical
         stackView.distribution = .fill

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/CategoryModalViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/CategoryModalViewController.swift
@@ -37,13 +37,13 @@ class CategoryModalViewController: ModalViewController {
     
     lazy var cateringStoreButtonView: UIStackView = {
         let imageView = UIImageView()
-        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0))
+        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 11, right: 0))
         let stackView = UIStackView(arrangedSubviews: [imageView, label])
         stackView.axis = .vertical
         stackView.distribution = .fill
         stackView.spacing = 0
         stackView.alignment = .center
-        imageView.image = resizedImage(image: UIImage(named: "cateringCategory"), width: 160, height: 100)
+        imageView.image = resizedImage(image: UIImage(named: "cateringCategory"), width: ModalHeight.median.value/2.5, height: ModalHeight.median.value/4)
         imageView.contentMode = .scaleAspectFill
         label.text = "요식업"
         label.textColor = .white
@@ -59,13 +59,13 @@ class CategoryModalViewController: ModalViewController {
     
     lazy var hairdressingShop: UIStackView = {
         let imageView = UIImageView()
-        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0))
+        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 11, right: 0))
         let stackView = UIStackView(arrangedSubviews: [imageView, label])
         stackView.axis = .vertical
         stackView.distribution = .fill
         stackView.spacing = 0
         stackView.alignment = .center
-        imageView.image = resizedImage(image: UIImage(named: "hairCategory"), width: 160, height: 100)
+        imageView.image = resizedImage(image: UIImage(named: "hairCategory"), width: ModalHeight.median.value/2.5, height: ModalHeight.median.value/4)
         imageView.contentMode = .scaleAspectFill
         label.text = "미용업"
         label.textColor = .white
@@ -81,13 +81,13 @@ class CategoryModalViewController: ModalViewController {
     
     lazy var laundryShop: UIStackView = {
         let imageView = UIImageView()
-        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0))
+        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 11, right: 0))
         let stackView = UIStackView(arrangedSubviews: [imageView, label])
         stackView.axis = .vertical
         stackView.distribution = .fill
         stackView.spacing = 0
         stackView.alignment = .center
-        imageView.image = resizedImage(image: UIImage(named: "laundryCategory"), width: 160, height: 100)
+        imageView.image = resizedImage(image: UIImage(named: "laundryCategory"), width: ModalHeight.median.value/2.5, height: ModalHeight.median.value/4)
         imageView.contentMode = .scaleAspectFill
         label.text = "세탁업"
         label.textColor = .white
@@ -103,13 +103,13 @@ class CategoryModalViewController: ModalViewController {
     
     lazy var serviceShop: UIStackView = {
         let imageView = UIImageView()
-        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 16, right: 0))
+        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 11, right: 0))
         let stackView = UIStackView(arrangedSubviews: [imageView, label])
         stackView.axis = .vertical
         stackView.distribution = .fill
         stackView.spacing = 0
         stackView.alignment = .center
-        imageView.image = resizedImage(image: UIImage(named: "serviceCategory"), width: 160, height: 100)
+        imageView.image = resizedImage(image: UIImage(named: "serviceCategory"), width: ModalHeight.median.value/2.5, height: ModalHeight.median.value/4)
         imageView.contentMode = .scaleAspectFill
         label.text = "서비스업"
         label.textColor = .white
@@ -127,7 +127,7 @@ class CategoryModalViewController: ModalViewController {
         let stackView = UIStackView(arrangedSubviews: [cateringStoreButtonView, hairdressingShop])
         stackView.axis = .horizontal
         stackView.distribution = .fillEqually
-        stackView.spacing = 30
+        stackView.spacing = ModalHeight.median.value/18
         return stackView
     }()
     
@@ -135,14 +135,14 @@ class CategoryModalViewController: ModalViewController {
         let stackView = UIStackView(arrangedSubviews: [laundryShop, serviceShop])
         stackView.axis = .horizontal
         stackView.distribution = .fillEqually
-        stackView.spacing = 30
+        stackView.spacing = ModalHeight.median.value/18
         return stackView
     }()
     
     lazy var totalStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [upperStackView, underStackView])
         stackView.axis = .vertical
-        stackView.spacing = 30
+        stackView.spacing = ModalHeight.median.value/18
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
@@ -178,7 +178,7 @@ class CategoryModalViewController: ModalViewController {
         NSLayoutConstraint.activate([
             totalStackView.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width - 30),
             totalStackView.leftAnchor.constraint(equalTo: innerScrollView.leftAnchor, constant: 15),
-            totalStackView.topAnchor.constraint(equalTo: self.textLabel.bottomAnchor, constant: 30),
+            totalStackView.topAnchor.constraint(equalTo: self.textLabel.bottomAnchor, constant: ModalHeight.median.value/18),
             totalStackView.bottomAnchor.constraint(equalTo: innerScrollView.bottomAnchor, constant: -50),
             totalStackView.rightAnchor.constraint(equalTo: innerScrollView.rightAnchor, constant: -15)
         ])

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/CategoryModalViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/CategoryModalViewController.swift
@@ -37,7 +37,7 @@ class CategoryModalViewController: ModalViewController {
     
     lazy var cateringStoreButtonView: UIStackView = {
         let imageView = UIImageView()
-        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 11, right: 0))
+        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 12, right: 0))
         let stackView = UIStackView(arrangedSubviews: [imageView, label])
         stackView.axis = .vertical
         stackView.distribution = .fill
@@ -59,7 +59,7 @@ class CategoryModalViewController: ModalViewController {
     
     lazy var hairdressingShop: UIStackView = {
         let imageView = UIImageView()
-        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 11, right: 0))
+        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 12, right: 0))
         let stackView = UIStackView(arrangedSubviews: [imageView, label])
         stackView.axis = .vertical
         stackView.distribution = .fill
@@ -81,7 +81,7 @@ class CategoryModalViewController: ModalViewController {
     
     lazy var laundryShop: UIStackView = {
         let imageView = UIImageView()
-        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 11, right: 0))
+        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 12, right: 0))
         let stackView = UIStackView(arrangedSubviews: [imageView, label])
         stackView.axis = .vertical
         stackView.distribution = .fill
@@ -103,7 +103,7 @@ class CategoryModalViewController: ModalViewController {
     
     lazy var serviceShop: UIStackView = {
         let imageView = UIImageView()
-        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 11, right: 0))
+        let label = BasePaddingLabel(padding: UIEdgeInsets(top: 0, left: 0, bottom: 12, right: 0))
         let stackView = UIStackView(arrangedSubviews: [imageView, label])
         stackView.axis = .vertical
         stackView.distribution = .fill

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/DetailModalViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/DetailModalViewController.swift
@@ -41,6 +41,7 @@ class DetailModalViewController: ModalViewController {
         let search = UIButton()
         search.setImage(UIImage(systemName: "magnifyingglass.circle.fill", withConfiguration: UIImage.SymbolConfiguration(scale: .large)), for: .normal)
         search.addTarget(self, action: #selector(searchToNaver), for: .touchUpInside)
+        search.tintColor = UIColor(named: "MainColor")
         return search
     }()
     
@@ -100,8 +101,9 @@ class DetailModalViewController: ModalViewController {
     
     lazy var infoSymbolCopyButton: UIButton = {
         let infoSymbolCopy = UIButton()
-        infoSymbolCopy.setImage(UIImage(systemName: "doc.on.doc.fill"), for: .normal)
+        infoSymbolCopy.setImage(UIImage(systemName: "square.fill.on.square.fill"), for: .normal)
         infoSymbolCopy.addTarget(self, action: #selector(copyAddress), for: .touchUpInside)
+        infoSymbolCopy.tintColor = UIColor(named: "MainColor")
         return infoSymbolCopy
     }()
     
@@ -117,6 +119,7 @@ class DetailModalViewController: ModalViewController {
         let infoSymbolPhone = UIButton()
         infoSymbolPhone.setImage(UIImage(systemName: "phone.fill"), for: .normal)
         infoSymbolPhone.addTarget(self, action: #selector(phoneCall), for: .touchUpInside)
+        infoSymbolPhone.tintColor = UIColor(named: "MainColor")
         return infoSymbolPhone
     }()
     
@@ -201,7 +204,7 @@ class DetailModalViewController: ModalViewController {
         let isFavoriteShop = viewModel.isFavoriteShop(selectedShop)
         favoriteButton.setImage(isFavoriteShop ? UIImage(systemName: "heart.fill", withConfiguration: UIImage.SymbolConfiguration(scale: .large)) : UIImage(systemName: "heart", withConfiguration: UIImage.SymbolConfiguration(scale: .large)), for: .normal)
         
-        favoriteButton.tintColor = isFavoriteShop ? UIColor.red : UIColor.gray
+        favoriteButton.tintColor = isFavoriteShop ? UIColor(named: "SubColorRed") : UIColor.gray
     }
     
     @objc func searchToNaver() {

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/DetailModalViewController.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/DetailModalViewController.swift
@@ -229,7 +229,7 @@ class DetailModalViewController: ModalViewController {
        }
     
     func showToast(message : String, font: UIFont = UIFont.systemFont(ofSize: 14.0)) {
-            let toastLabel = UILabel(frame: CGRect(x: self.view.frame.size.width/2 - 75, y: self.view.frame.size.height-350, width: 150, height: 35))
+        let toastLabel = UILabel(frame: CGRect(x: self.view.frame.size.width/2 - 75, y: ModalHeight.zero.value-40, width: 150, height: 35))
             toastLabel.backgroundColor = UIColor.black.withAlphaComponent(0.6)
             toastLabel.textColor = UIColor.white
             toastLabel.font = font

--- a/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/ModalCollectionViewCell/StoreListViewCell.swift
+++ b/DaeguGoodPriceShop/DaeguGoodPriceShop/View/ModalViewController/ModalCollectionViewCell/StoreListViewCell.swift
@@ -30,9 +30,9 @@ class StoreListViewCell: UICollectionViewCell {
     
     private lazy var callButton: UIButton = {
         let button = UIButton()
-        button.setImage(UIImage(systemName: "phone"), for: .normal)
+        button.setImage(UIImage(systemName: "phone.fill"), for: .normal)
         button.addTarget(self, action: #selector(phoneCall), for: .touchUpInside)
-        button.tintColor = UIColor(displayP3Red: 50/255, green: 105/255, blue: 217/255, alpha: 1.0)
+        button.tintColor = UIColor(named: "MainColor")
         button.backgroundColor = .systemBackground
         button.layer.cornerRadius = 10
         button.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
# Issue Number
🔒 Close #181

## Refactor features

- UI Change to DetailView's Button Image & Color (Figma 디자인 기준 적용)
[Before]
<img width="369" alt="스크린샷 2022-07-31 오후 5 53 08" src="https://user-images.githubusercontent.com/40324511/182018543-4e19db6c-4170-4186-8d8a-f6dc2e7823c6.png">

[After]
<img width="358" alt="스크린샷 2022-07-31 오후 5 41 37" src="https://user-images.githubusercontent.com/40324511/182018037-1c5182ba-04e2-409f-8853-25431dbe6398.png">

- UI Change to StoreList CellView's CallButton 
[Before]
<img width="360" alt="스크린샷 2022-07-31 오후 5 53 26" src="https://user-images.githubusercontent.com/40324511/182018564-6a8a3ebc-cc43-4535-924f-76f422e4a782.png">

[After]
<img width="346" alt="스크린샷 2022-07-31 오후 5 42 18" src="https://user-images.githubusercontent.com/40324511/182018068-8df67582-d1ed-4d20-8679-b5ce88e8b2d4.png">

- UI Change to Category
[Before] 고정형일시 iPhone8 Plus 화면크기 이하 기종에서 아래 처럼 UI 깨짐
<img width="358" alt="스크린샷 2022-07-31 오후 5 48 59" src="https://user-images.githubusercontent.com/40324511/182018368-5d15648e-cdb0-4b07-86aa-a46930ca3036.png">

[After] AutoLayOut 적용시 모든 iphone기종에서 아래와 같이 동일한 UI를 보여줌 
<img width="345" alt="스크린샷 2022-07-31 오후 5 42 34" src="https://user-images.githubusercontent.com/40324511/182018075-47b22e3a-adf3-4ad4-93c3-c5c50081ebdf.png">